### PR TITLE
Concurrent connection support and tracking

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -56,7 +56,7 @@ type ConcurrencyCounter struct {
 }
 
 func (c *ConcurrencyCounter) Get() int32 {
-	return c.concurrency
+	return atomic.LoadInt32(&c.concurrency)
 }
 
 func (c *ConcurrencyCounter) Increment() {

--- a/pool.go
+++ b/pool.go
@@ -148,28 +148,24 @@ func (p *Pool) Close() {
 	p.unhealthyClients = nil
 	p.mu.Unlock()
 
-	if clients == nil {
-		return
-	}
-
-	close(clients)
-	for client := range clients {
-		if client.ClientConn == nil {
-			continue
+	if clients != nil {
+		close(clients)
+		for client := range clients {
+			if client.ClientConn == nil {
+				continue
+			}
+			client.ClientConn.Close()
 		}
-		client.ClientConn.Close()
 	}
 
-	if unhealthyClients == nil {
-		return
-	}
-
-	close(unhealthyClients)
-	for client := range unhealthyClients {
-		if client.ClientConn == nil {
-			continue
+	if unhealthyClients != nil {
+		close(unhealthyClients)
+		for client := range unhealthyClients {
+			if client.ClientConn == nil {
+				continue
+			}
+			client.ClientConn.Close()
 		}
-		client.ClientConn.Close()
 	}
 }
 


### PR DESCRIPTION
## description
Adding support for multiplexing connections.
There aren't limits, we'll multiplex as much as necessary.
We track the active concurrency on a given connection, and won't prematurely close connections until that concurrency is zero.

Timeout tests are removed for now, as there's no wait and they just fail.

## Why are we doing this?
HTTP/2 (grpc's connection protocol) handles multiplexing all on its own. However, back-to-back testing[0] shows that as concurrency grows, tail latencies suffer. 
Since we're deeply concerned with tail latency, we need to investigate other options, which is how we arrived at connection pooling to begin with.
It doesn't make a ton of sense to grow a connection pool indefinitely (for example, growing a pool whenever we're contended). However, since HTTP/2 multiplexing works well at lower concurrency levels, we can take advantage of that while giving ourselves a lever to avoid getting _too_ concurrent.

[0] Testing was performed at concurrent levels from 10 to 2000 concurrent requests. Testing load was powered by ghz (https://github.com/tristans-stripe/ghz).